### PR TITLE
Support environment contentful parameter

### DIFF
--- a/src/initContentful.js
+++ b/src/initContentful.js
@@ -7,11 +7,13 @@ function create({
   cache,
   host,
   space,
+  environment,
 }) {
   return new ContentfulClient({
     host,
     accessToken,
     space,
+    environment,
     ssrMode: !!(process.browser) === false,
     cache: cache instanceof ContentfulCache
       ? cache

--- a/src/initContentful.js
+++ b/src/initContentful.js
@@ -7,7 +7,7 @@ function create({
   cache,
   host,
   space,
-  environment,
+  environment = 'master',
 }) {
   return new ContentfulClient({
     host,

--- a/src/withContentful.js
+++ b/src/withContentful.js
@@ -39,6 +39,7 @@ export default ({ accessToken, host, space }) => {
           accessToken,
           host,
           space,
+          environment,
         });
 
         if (!process.browser) {
@@ -73,6 +74,7 @@ export default ({ accessToken, host, space }) => {
           accessToken,
           host,
           space,
+          environment,
           cache: Flatted.stringify(contentful.cache.extract()),
         };
 

--- a/src/withContentful.js
+++ b/src/withContentful.js
@@ -6,7 +6,7 @@ import { getDisplayName } from './hoc-utils';
 import initContentful from './initContentful';
 const Flatted = require('flatted/cjs');
 
-export default ({ accessToken, host, space }) => {
+export default ({ accessToken, host, space, environment }) => {
   return (ComposedComponent) => {
     const propTypes = {
       contentfulState: PropTypes.shape(),
@@ -39,6 +39,7 @@ export default ({ accessToken, host, space }) => {
           accessToken,
           host,
           space,
+          environment,
         });
 
         if (!process.browser) {
@@ -73,6 +74,7 @@ export default ({ accessToken, host, space }) => {
           accessToken,
           host,
           space,
+          environment,
           cache: Flatted.stringify(contentful.cache.extract()),
         };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,7 @@ export interface withContentfulParams {
   accessToken: string;
   host: string;
   space: string;
+  environment?: string;
 }
 
 export type withContentful = (params: withContentfulParams) => Component;


### PR DESCRIPTION
Adds support for the `environment` contentful client parameter. 

Thanks for your effort on this package, it's making our next.js project much more straightforward. We appreciate your timeliness, since this update is to better support a client project. Let me know if I can do anything to make your life a little easier.